### PR TITLE
Fix: Change id field in UserCreateSerializer

### DIFF
--- a/user-api/mypage/serializers/user_serializers.py
+++ b/user-api/mypage/serializers/user_serializers.py
@@ -2,7 +2,7 @@ from mypage.models import Ticket, Bookmark, Buy, User, Account
 
 from rest_framework import serializers
 
-from django.contrib.auth import get_user_model
+# from django.contrib.auth import get_user_model
 from django.contrib.gis.geos import Point
 
 from math import sin, cos, radians, degrees, acos
@@ -22,8 +22,8 @@ class UserCreateSerializer(serializers.ModelSerializer):
     """
     회원가입
     """
-    id = serializers.PrimaryKeyRelatedField(queryset=get_user_model().objects.all())
-    # id = serializers.IntegerField()
+    # id = serializers.PrimaryKeyRelatedField(queryset=get_user_model().objects.all())
+    id = serializers.IntegerField()
     account = AccountSerializer(required=False)
     latitude = serializers.FloatField(write_only=True)
     longitude = serializers.FloatField(write_only=True)


### PR DESCRIPTION
transaction 적용했하여 request 보낸 시점에 social user가 아직 DB에
저장되지 않았으므로 primarykey 대신 integer를 사용