### PR TITLE
Modify user account and image views

### DIFF
--- a/user-api/config/settings/local.py
+++ b/user-api/config/settings/local.py
@@ -46,8 +46,8 @@ MEDIA_LOCATION = f'{AWS_LOCATION}/'.lstrip('/') + 'media/user-api'
 
 # Storage Backend
 DEFAULT_FILE_STORAGE = 'config.storages.MediaS3Boto3Storage'
-STATICFILES_STORAGE = 'config.storages.StaticS3Boto3Storage'
+# STATICFILES_STORAGE = 'config.storages.StaticS3Boto3Storage'
 
 # Static files (CSS, JavaScript, Images)
-STATIC_URL = f'https://{AWS_S3_CUSTOM_DOMAIN}/{STATIC_LOCATION}/'
-STATICFILES_DIRS = []
+# STATIC_URL = f'https://{AWS_S3_CUSTOM_DOMAIN}/{STATIC_LOCATION}/'
+# STATICFILES_DIRS = []

--- a/user-api/mypage/files.py
+++ b/user-api/mypage/files.py
@@ -1,0 +1,17 @@
+from django.db.models import ImageField
+from django.db.models.fields.files import ImageFieldFile
+
+from config.storages import StaticS3Boto3Storage, MediaS3Boto3Storage
+
+
+class DynamicStorageImageFieldFile(ImageFieldFile):
+    def __init__(self, instance, field, name):
+        super().__init__(instance, field, name)
+        if instance.is_custom_image:
+            self.storage = MediaS3Boto3Storage()
+        else:
+            self.storage = StaticS3Boto3Storage()
+
+
+class DynamicStorageImageField(ImageField):
+    attr_class = DynamicStorageImageFieldFile

--- a/user-api/mypage/models.py
+++ b/user-api/mypage/models.py
@@ -5,6 +5,7 @@
 #   * Make sure each ForeignKey and OneToOneField has `on_delete` set to the desired behavior
 #   * Remove `managed = False` lines if you wish to allow Django to create, modify, and delete the table
 # Feel free to rename the models, but don't rename db_table values or field names.
+from mypage.files import DynamicStorageImageField
 from django.contrib.gis.db import models
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
@@ -13,7 +14,7 @@ import os
 from uuid import uuid4
 
 TEST = False
-IMAGE_DIR = 'img'
+IMAGE_DIR = 'mypage/img'
 
 
 def get_file_name(_instance, filename):
@@ -41,7 +42,8 @@ class User(models.Model):
     detailed_address = models.CharField(max_length=255, blank=True)
     check_terms_of_service = models.BooleanField()
     check_privacy_policy = models.BooleanField()
-    image = models.ImageField(upload_to=get_file_path, max_length=255, null=True)
+    image = DynamicStorageImageField(upload_to=get_file_path, max_length=255, null=True)
+    is_custom_image = models.BooleanField(default=False)
 
     class Meta:
         managed = TEST
@@ -62,7 +64,7 @@ class Account(models.Model):
 def delete_fields(sender, instance: User, **kwargs):
     if instance.account:
         instance.account.delete()
-    if instance.image:
+    if instance.image and instance.is_custom_image:
         instance.image.delete(save=False)
 
 

--- a/user-api/mypage/models.py
+++ b/user-api/mypage/models.py
@@ -5,19 +5,26 @@
 #   * Make sure each ForeignKey and OneToOneField has `on_delete` set to the desired behavior
 #   * Remove `managed = False` lines if you wish to allow Django to create, modify, and delete the table
 # Feel free to rename the models, but don't rename db_table values or field names.
-from django.conf import settings
 from django.contrib.gis.db import models
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
 
 import os
 from uuid import uuid4
 
 TEST = False
+IMAGE_DIR = 'img'
 
 
-def get_file_path(_instance, filename):
+def get_file_name(_instance, filename):
     uuid_name = uuid4().hex
     ext = os.path.splitext(filename)[-1]
-    return f'image/{uuid_name}{ext}'
+    return f'{uuid_name}{ext}'
+
+
+def get_file_path(*args, **kwargs):
+    file_name = get_file_name(*args, **kwargs)
+    return f'{IMAGE_DIR}/{file_name}'
 
 
 class User(models.Model):
@@ -49,6 +56,14 @@ class Account(models.Model):
     class Meta:
         managed = TEST
         db_table = 'Account'
+
+
+@receiver(post_delete, sender=User)
+def delete_fields(sender, instance: User, **kwargs):
+    if instance.account:
+        instance.account.delete()
+    if instance.image:
+        instance.image.delete(save=False)
 
 
 class Bookmark(models.Model):

--- a/user-api/mypage/serializers/user_serializers.py
+++ b/user-api/mypage/serializers/user_serializers.py
@@ -123,7 +123,7 @@ class UserImageSerializer(serializers.ModelSerializer):
     """
     이미지 파일 등록/수정/삭제
     """
-    image = serializers.ImageField(use_url=True, allow_null=True)
+    image = serializers.ImageField(use_url=True, allow_null=False)
 
     class Meta:
         model = User

--- a/user-api/mypage/views/user_views.py
+++ b/user-api/mypage/views/user_views.py
@@ -2,7 +2,7 @@ from mypage.models import User, Account
 from mypage.serializers import user_serializers as serializers
 
 from rest_framework import mixins, generics, status, permissions
-from rest_framework.parsers import MultiPartParser
+from rest_framework.parsers import MultiPartParser, JSONParser
 from rest_framework.response import Response
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
@@ -110,12 +110,16 @@ class UserImageView(generics.RetrieveUpdateDestroyAPIView):
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
-        instance.image = None
-        instance.save()
-        return Response({'detail': '삭제가 완료되었습니다.'}, status=status.HTTP_200_OK)
+        if instance.image:
+            instance.image.delete(save=True)
+            return Response({'detail': '삭제가 완료되었습니다.'}, status=status.HTTP_200_OK)
+        else:
+            raise Http404
 
     @swagger_auto_schema(
-        responses={200: '삭제가 완료되었습니다.'},
+        responses={200: '삭제가 완료되었습니다.',
+                   401: '자격 인증데이터(authentication credentials)가 제공되지 않았습니다.',
+                   404: '찾을 수 없습니다.'},
     )
     def delete(self, request, *args, **kwargs):
         return self.destroy(request, *args, **kwargs)

--- a/user-api/mypage/views/user_views.py
+++ b/user-api/mypage/views/user_views.py
@@ -20,7 +20,7 @@ class UserCreateView(generics.CreateAPIView):
     permission_classes = [permissions.AllowAny]
 
 
-class UserDetailView(generics.RetrieveUpdateDestroyAPIView):
+class UserDetailView(generics.RetrieveDestroyAPIView, mixins.UpdateModelMixin):
     """
     마이페이지 (+회원탈퇴)
     """
@@ -41,10 +41,6 @@ class UserDetailView(generics.RetrieveUpdateDestroyAPIView):
         마이페이지; 사용자ID가 {id}인 사용자의 상세 정보
         """
         return self.retrieve(request, *args, **kwargs)
-
-    def perform_destroy(self, instance: User):
-        instance.account.delete()
-        instance.delete()
 
     @swagger_auto_schema(
         manual_parameters=[openapi.Parameter('id', openapi.IN_PATH, type=openapi.TYPE_INTEGER, description='사용자ID'), ],


### PR DESCRIPTION
## models
- media image upload 경로 수정하여 static 파일 하위 경로와 일치시킴
- User model에 is_custom_image 필드 추가
- User model의 image 필드를 DynamicStorageImageField로 변경
  files에 is_custon_image에 따라 동적으로 imagefield file의 storage
  를 변경하는 DynamicStorageImageFieldFile과 이를 사용하는
  DynamicStorageImageFieldFile를 정의
- 사용자의 프로필 이미지가 media file인 경우에만 AWS S3에서 파일 삭제

## serializers
- 기존 multipart 형태로 파일 입력받는 serializer를
  UserImageFileSerializer로 이름 변경
- url을 이용하여 static image를 User image 필드에 저장하는
  UserImageUrlSerializer 정의. AWS S3에 파일 존재하는지 검사하여
  validate.

## views
- HTTP header의 Content-Type에 따라 다른 type의 field가 정의된
  serializer를 사용
- DELETE user-image에서 사용자의 프로필 이미지가 media file인
  경우에만 AWS S3에서 파일 삭제. 사용자 이미지 없으면 404 반환
- user-image update에서 disallow null value
- user-image api에서 patch method 삭제